### PR TITLE
:recycle: Add support for extras_require

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,20 @@
 
 [pipgrip](https://github.com/ddelange/pipgrip) is a lightweight pip dependency resolver with deptree preview functionality based on the [PubGrub algorithm](https://medium.com/@nex3/pubgrub-2fb6470504f), which is also used by [poetry](https://github.com/python-poetry/poetry). For one or more [PEP 508](https://www.python.org/dev/peps/pep-0508/) dependency specifications, pipgrip recursively fetches/builds the Python wheels necessary for version solving, and optionally renders the full resulting dependency tree.
 
-<!-- why is it different from poetry?
-  why is it different from pipdeptry?
+<!--
   give example with multiple packages
   reversed tree
   two times pypi.org in `looking in indexes`?
   multicore pip?
 -->
 
+#### pipgrip vs. poetry
+
+[poetry](https://github.com/python-poetry/poetry) offers package management with dependency resolution, essentially replacing pip/setuptools. This means that poetry packages don't contain `setup.py`, and hence are not compatible with `pip install -e`: poetry projects would have to be converted to setuptools-based projects with e.g. [dephell](https://github.com/dephell/dephell). To avoid such hassle, pipgrip only requires the selected package(s) + dependencies to be available to pip in the ususal way.
+
+#### pipgrip vs. pipdeptree
+
+For offline usage, pipdeptree](https://github.com/naiquevin/pipdeptree) can inspect the current environment and show how the currently installed packages relate to each other. This however requires the packages to be pip-installed, and (despite warnings about e.g. cyclic dependencies) offers no form of dependency resolution since it's only based on the (single) package versions installed in the environment. Such shortcomings are avoided when using pipgrip, since packages don't need to be installed and all versions available to pip are considered.
 
 ## Installation
 
@@ -36,7 +42,7 @@ This package can be used to:
   - `pipgrip --tree .`
 - Install complex packages without worries using:
   - ``pip install -U --no-deps `pipgrip --pipe aiobotocore[awscli]` ``
-- Generate a lockfile with a complete working set of dependencies (see [known caveats](#known-caveats)):
+- Generate a lockfile with a complete working set of dependencies for worriless installs (see [known caveats](#known-caveats)):
   - `pipgrip --lock -tree aiobotocore[awscli] && pip install -U --no-deps -r ./pipgrip.lock`
   - `pipgrip aiobotocore[awscli] | pip install -U --no-deps -r /dev/stdin`
 
@@ -152,7 +158,7 @@ keras==2.2.2 (2.2.2)
 - Package names are canonicalised in wheel metadata, resulting in e.g. `path.py -> path-py` and `keras_preprocessing -> keras-preprocessing` in output
 - [VCS Support](https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support) isn't implemented yet
 - `--reversed-tree` isn't implemented yet
-- Since `pip install -r` does not accept `.` as requirement, `--pipe` format must be used when installing local projects
+- Since `pip install -r` does not accept `.` as requirement, it is omitted from lockfiles, so `--pipe` should be used when installing local projects
 - Installing packages using pipgrip is not very intuitive, so maybe pipgrip needs a stable `--install` flag
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@
 
 [pipgrip](https://github.com/ddelange/pipgrip) is a lightweight pip dependency resolver with deptree preview functionality based on the [PubGrub algorithm](https://medium.com/@nex3/pubgrub-2fb6470504f), which is also used by [poetry](https://github.com/python-poetry/poetry). For one or more [PEP 508](https://www.python.org/dev/peps/pep-0508/) dependency specifications, pipgrip recursively fetches/builds the Python wheels necessary for version solving, and optionally discovers and renders the full resulting dependency tree.
 
+<!-- why is it different from poetry?
+  why is it different from pipdeptry?
+  give example with multiple packages
+  extras down the tree are lost because we pass key not str (e.g. scoutbee==0.13.0 see boto3)
+  0.1.0 as initial release
+  remove 500 max tries
+  reversed tree
+  two times pypi.org in `looking in indexes`?
+-->
+
 
 ## Installation
 
@@ -28,9 +38,9 @@ This package can be used to:
   - `pipgrip --tree .`
 - Install complex packages without worries using:
   - ``pip install -U --no-deps `pipgrip --pipe aiobotocore[awscli]` ``
-- Generate a lockfile with a complete working set of dependencies (see [known caveats](#known-caveats))
-  - `pipgrip aiobotocore[awscli] | pip install -U --no-deps -r /dev/stdin`
+- Generate a lockfile with a complete working set of dependencies (see [known caveats](#known-caveats)):
   - `pipgrip --lock -tree aiobotocore[awscli] && pip install -U --no-deps -r ./pipgrip.lock`
+  - `pipgrip aiobotocore[awscli] | pip install -U --no-deps -r /dev/stdin`
 
 ```sh
 $ pipgrip --help

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
   give example with multiple packages
   extras down the tree are lost because we pass key not str (e.g. scoutbee==0.13.0 see boto3)
   0.1.0 as initial release
-  remove 500 max tries
   reversed tree
   two times pypi.org in `looking in indexes`?
 -->
@@ -77,7 +76,7 @@ Exhaustive dependency trees without the need to install any packages (at most bu
 ```sh
 $ pipgrip --tree pipgrip
 
-pipgrip (0.0.1)
+pipgrip (0.1.0)
 ├── anytree (2.7.3)
 │   └── six (1.13.0)
 ├── click (7.0)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 <!-- [![codecov](https://codecov.io/gh/ddelange/pipgrip/branch/master/graph/badge.svg?token=<add_token_here>)](https://codecov.io/gh/ddelange/pipgrip) -->
 
-[pipgrip](https://github.com/ddelange/pipgrip) is a lightweight pip dependency resolver with deptree preview functionality based on the [PubGrub algorithm](https://medium.com/@nex3/pubgrub-2fb6470504f), which is also used by [poetry](https://github.com/python-poetry/poetry). For one or more [PEP 508](https://www.python.org/dev/peps/pep-0508/) dependency specifications, pipgrip recursively fetches/builds the Python wheels necessary for version solving, and optionally discovers and renders the full resulting dependency tree.
+[pipgrip](https://github.com/ddelange/pipgrip) is a lightweight pip dependency resolver with deptree preview functionality based on the [PubGrub algorithm](https://medium.com/@nex3/pubgrub-2fb6470504f), which is also used by [poetry](https://github.com/python-poetry/poetry). For one or more [PEP 508](https://www.python.org/dev/peps/pep-0508/) dependency specifications, pipgrip recursively fetches/builds the Python wheels necessary for version solving, and optionally renders the full resulting dependency tree.
 
 <!-- why is it different from poetry?
   why is it different from pipdeptry?

--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@
 <!-- why is it different from poetry?
   why is it different from pipdeptry?
   give example with multiple packages
-  extras down the tree are lost because we pass key not str (e.g. scoutbee==0.13.0 see boto3)
-  0.1.0 as initial release
   reversed tree
   two times pypi.org in `looking in indexes`?
+  multicore pip?
 -->
 
 
@@ -76,7 +75,7 @@ Exhaustive dependency trees without the need to install any packages (at most bu
 ```sh
 $ pipgrip --tree pipgrip
 
-pipgrip (0.1.0)
+pipgrip (0.0.3)
 ├── anytree (2.7.3)
 │   └── six (1.13.0)
 ├── click (7.0)

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -33,7 +33,7 @@ def flatten(d):
             for key2, val2 in deeper:
                 if key2 in out and out[key2] != val2:
                     raise RuntimeError(
-                        "{} has not been solved: both {} and {} found... Please report this bug",
+                        "{} has not been solved: both {} and {} found... Please file an issue on GitHub.",
                         key2,
                         val0,
                         val2,
@@ -43,10 +43,12 @@ def flatten(d):
     return out
 
 
-def _find_version(source, dep):
-    if dep.name not in source._packages:
-        source._versions_for(dep.name, source.convert_dependency(dep).constraint)
-    versions = [k for k, v in source._packages[dep.name].items() if v is not None]
+def _find_version(source, dep, extras):
+    if dep.package not in source._packages:
+        source._versions_for(dep.package, source.convert_dependency(dep).constraint)
+    versions = [
+        k for k, v in source._packages[dep.package][extras].items() if v is not None
+    ]
     return versions[-1]
 
 
@@ -56,7 +58,10 @@ def _recurse_dependencies(
     packages = OrderedDict()
     for dep in dependencies:
         name = dep.name
-        resolved_version = decision_packages.get(name) or _find_version(source, dep)
+        extras = dep.package.req.extras
+        resolved_version = decision_packages.get(name) or _find_version(
+            source, dep, extras
+        )
 
         tree_node = Node(
             name,
@@ -83,7 +88,7 @@ def _recurse_dependencies(
         packages[(name, str(resolved_version))] = _recurse_dependencies(
             source,
             decision_packages,
-            source._packages[name][resolved_version],
+            source._packages[dep.package][extras][resolved_version],
             tree_root,
             tree_node,
         )

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -58,8 +58,6 @@ def _recurse_dependencies(
         name = dep.name
         resolved_version = decision_packages.get(name) or _find_version(source, dep)
 
-        # detect cyclic depenencies
-        matches = findall_by_attr(tree_root, name)
         tree_node = Node(
             name,
             version=resolved_version,
@@ -69,6 +67,9 @@ def _recurse_dependencies(
             metadata=source._packages_metadata[name][str(resolved_version)],
             pip_string=dep.pip_string,
         )
+
+        # detect cyclic depenencies
+        matches = findall_by_attr(tree_root, name)
         if matches and matches[0] in tree_node.ancestors:
             logger.warning(
                 "Cyclic dependency found: %s depends on %s and vice versa.",

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -59,7 +59,7 @@ def _recurse_dependencies(
     for dep in dependencies:
         name = dep.name
         extras = dep.package.req.extras
-        resolved_version = decision_packages.get(name) or _find_version(
+        resolved_version = decision_packages.get(dep.package) or _find_version(
             source, dep, extras
         )
 
@@ -88,7 +88,7 @@ def _recurse_dependencies(
         packages[(name, str(resolved_version))] = _recurse_dependencies(
             source,
             decision_packages,
-            source._packages[dep.package][extras][resolved_version],
+            source.dependencies_for(dep.package, resolved_version),
             tree_root,
             tree_node,
         )

--- a/src/pipgrip/libs/mixology/constraint.py
+++ b/src/pipgrip/libs/mixology/constraint.py
@@ -96,7 +96,7 @@ class Constraint(object):
             return "every version of {}".format(self.package)
 
         return "{} ({})".format(
-            self.package, "*" if self.is_any() else str(self.constraint)
+            self.package.req.extras_name, "*" if self.is_any() else str(self.constraint)
         )
 
     def __str__(self):

--- a/src/pipgrip/libs/mixology/package.py
+++ b/src/pipgrip/libs/mixology/package.py
@@ -30,6 +30,9 @@ class Package(object):
     def __eq__(self, other):  # type: () -> bool
         return str(other) == self.name
 
+    def __ne__(self, other):  # type: () -> bool
+        return not self.__eq__(other)
+
     def __str__(self):  # type: () -> str
         return self._name
 

--- a/src/pipgrip/libs/mixology/package.py
+++ b/src/pipgrip/libs/mixology/package.py
@@ -34,7 +34,7 @@ class Package(object):
         return self._name
 
     def __repr__(self):  # type: () -> str
-        return 'Package("{}")'.format(self.name)
+        return 'Package("{}")'.format(self.req.extras_name)
 
     def __hash__(self):
         return hash(self.name)

--- a/src/pipgrip/libs/mixology/package.py
+++ b/src/pipgrip/libs/mixology/package.py
@@ -1,10 +1,19 @@
-class Package(object):
-    """
-    A project's package.
-    """
+import pkg_resources
 
-    def __init__(self, name):  # type: (str) -> None
-        self._name = name
+from pipgrip.pipper import parse_req
+
+
+class Package(object):
+    """Represent a project's package."""
+
+    def __init__(self, pip_string):  # type: (str) -> None
+        if pip_string == "_root_":
+            req = parse_req(".")
+            req.key = "_root_"
+        else:
+            req = parse_req(pip_string)
+        self._name = req.key
+        self._req = req
 
     @classmethod
     def root(cls):  # type: () -> Package
@@ -13,6 +22,10 @@ class Package(object):
     @property
     def name(self):  # type: () -> str
         return self._name
+
+    @property
+    def req(self):  # type: () -> pkg_resources.Requirement
+        return self._req
 
     def __eq__(self, other):  # type: () -> bool
         return str(other) == self.name

--- a/src/pipgrip/libs/mixology/term.py
+++ b/src/pipgrip/libs/mixology/term.py
@@ -141,8 +141,13 @@ class Term(object):
                 to_return = self._non_empty_term(
                     self.constraint.union(other.constraint), False
                 )
-            to_return._constraint._package._req = parse_req(to_return.constraint.package.req.__str__(), extras=self.constraint.package.req.extras | other.constraint.package.req.extras)
-            to_return._package = self.constraint.package
+            if to_return is not None:
+                to_return._constraint._package._req = parse_req(
+                    to_return.constraint.package.req.__str__(),
+                    extras=self.constraint.package.req.extras
+                    | other.constraint.package.req.extras,
+                )
+                to_return._package = self.constraint.package
 
         elif self.is_positive() != other.is_positive():
             to_return = self if self.is_positive() else other

--- a/src/pipgrip/libs/mixology/version_solver.py
+++ b/src/pipgrip/libs/mixology/version_solver.py
@@ -62,7 +62,7 @@ class VersionSolver:
         self._propagate(self._source.root)
 
         packages_tried = 0
-        max_tries = 500
+        max_tries = -1
         while True:
             if packages_tried == max_tries:
                 raise SolverFailure("Stopping, {} packages tried.".format(max_tries))

--- a/src/pipgrip/libs/mixology/version_solver.py
+++ b/src/pipgrip/libs/mixology/version_solver.py
@@ -379,7 +379,7 @@ class VersionSolver:
 
         if not conflict:
             self._solution.decide(term.package, version)
-            logger.info("selecting {} ({})".format(term.package, str(version)))
+            logger.info("selecting {} ({})".format(term.package.req.extras_name, str(version)))
 
         return term.package
 

--- a/src/pipgrip/package_source.py
+++ b/src/pipgrip/package_source.py
@@ -177,7 +177,9 @@ class PackageSource(BasePackageSource):
 
         if self._packages[package][req.extras][version] is None:
             # populate dependencies for version
-            self.discover_and_add(req.__str__())
+            self.discover_and_add(
+                parse_req(str(package), req.extras).__str__() + "==" + str(version)
+            )
         return self._packages[package][req.extras][version]
 
     def convert_dependency(self, dependency):  # type: (Dependency) -> Constraint

--- a/src/pipgrip/package_source.py
+++ b/src/pipgrip/package_source.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict, Hashable, List, Optional
 
 from pipgrip.libs.mixology.constraint import Constraint
+from pipgrip.libs.mixology.package import Package
 from pipgrip.libs.mixology.package_source import PackageSource as BasePackageSource
 from pipgrip.libs.mixology.range import Range
 from pipgrip.libs.mixology.union import Union
@@ -17,9 +18,13 @@ class Dependency:
         self.constraint = parse_constraint(constraint or "*")
         self.pretty_constraint = constraint
         self.pip_string = pip_string
+        self.package = Package(pip_string)
 
     def __str__(self):  # type: () -> str
         return self.pretty_constraint
+
+    def __repr__(self):  # type: () -> str
+        return "Dependency({}, {})".format(self.pip_string, self.pretty_constraint)
 
 
 class PackageSource(BasePackageSource):
@@ -87,21 +92,21 @@ class PackageSource(BasePackageSource):
         return self._root_version
 
     def add(
-        self, name, version, deps=None
+        self, name, extras, version, deps=None
     ):  # type: (str, str, Optional[Dict[str, str]]) -> None
         version = Version.parse(version)
         if name not in self._packages:
-            self._packages[name] = {}
+            self._packages[name] = {extras: {}}
 
         # if already added without deps, assume now called with discovered deps and overwrite
-        if version in self._packages[name] and not (
-            deps is None or self._packages[name][version] is None
+        if version in self._packages[name][extras] and not (
+            deps is None or self._packages[name][extras][version] is None
         ):
             raise ValueError("{} ({}) already exists".format(name, version))
 
         # not existing and deps undiscovered
         if deps is None:
-            self._packages[name][version] = None
+            self._packages[name][extras][version] = None
             return
 
         dependencies = []
@@ -110,7 +115,7 @@ class PackageSource(BasePackageSource):
             constraint = ",".join(["".join(tup) for tup in req.specs])
             dependencies.append(Dependency(req.key, constraint, req.__str__()))
 
-        self._packages[name][version] = dependencies
+        self._packages[name][extras][version] = dependencies
 
     def discover_and_add(self, package):  # type: (str, str) -> None
         # converting from semver constraint to pkg_resources string
@@ -119,10 +124,12 @@ class PackageSource(BasePackageSource):
             package, self.index_url, self.extra_index_url, self.cache_dir, self.pre
         )
         for version in to_create["available"]:
-            self.add(req.key, version)
+            self.add(req.key, req.extras, version)
         self.add(
-            req.key, to_create["version"], deps=to_create["requires"],
+            req.key, req.extras, to_create["version"], deps=to_create["requires"],
         )
+
+        # currently unused
         if req.key not in self._packages_metadata:
             self._packages_metadata[req.key] = {}
         self._packages_metadata[req.key][to_create["version"]] = {
@@ -145,15 +152,17 @@ class PackageSource(BasePackageSource):
         Called by BasePackageSource.versions_for
 
         """
-        if package not in self._packages:
-            self.discover_and_add(
-                package + str(constraint).replace("||", "|").replace(" ", "")
-            )
+        extras = package.req.extras
+        req = parse_req(
+            str(package) + str(constraint).replace("||", "|").replace(" ", ""), extras
+        )
+        if package not in self._packages or extras not in self._packages[package]:
+            self.discover_and_add(req.__str__())
         if package not in self._packages:
             return []
 
         versions = []
-        for version in self._packages[package].keys():
+        for version in self._packages[package][extras].keys():
             if not constraint or constraint.allows_any(
                 Range(version, version, True, True)
             ):
@@ -162,13 +171,14 @@ class PackageSource(BasePackageSource):
         return sorted(versions, reverse=True)
 
     def dependencies_for(self, package, version):  # type: (Hashable, Any) -> List[Any]
+        req = package.req
         if package == self.root:
             return self._root_dependencies
 
-        if self._packages[package][version] is None:
+        if self._packages[package][req.extras][version] is None:
             # populate dependencies for version
-            self.discover_and_add(package + "==" + str(version))
-        return self._packages[package][version]
+            self.discover_and_add(req.__str__())
+        return self._packages[package][req.extras][version]
 
     def convert_dependency(self, dependency):  # type: (Dependency) -> Constraint
         """Convert a user-defined dependency into a format Mixology understands."""
@@ -194,4 +204,4 @@ class PackageSource(BasePackageSource):
             ]
             constraint = Union.of(*ranges)
 
-        return Constraint(dependency.name, constraint)
+        return Constraint(dependency.package, constraint)

--- a/src/pipgrip/package_source.py
+++ b/src/pipgrip/package_source.py
@@ -178,7 +178,10 @@ class PackageSource(BasePackageSource):
         if package == self.root:
             return self._root_dependencies
 
-        if req.extras not in self._packages[package] or self._packages[package][req.extras][version] is None:
+        if (
+            req.extras not in self._packages[package]
+            or self._packages[package][req.extras][version] is None
+        ):
             # populate dependencies for version
             self.discover_and_add(req.extras_name + "==" + str(version))
         return self._packages[package][req.extras][version]

--- a/src/pipgrip/pipper.py
+++ b/src/pipgrip/pipper.py
@@ -123,8 +123,8 @@ def _download_wheel(package, index_url, extra_index_url, pre, cache_dir):
         raise
     out = out.decode("utf-8").splitlines()[::-1]
     for i, line in enumerate(out):
-        if cache_dir in line or abs_cache_dir in line or "ephem-wheel-cache" in line:
-            if line.strip().startswith("Stored in directory"):
+        if cache_dir in line or abs_cache_dir in line or "Stored in directory" in line:
+            if "Stored in directory" in line:
                 # wheel was built
                 fname = [
                     part.replace("filename=", "")

--- a/src/pipgrip/pipper.py
+++ b/src/pipgrip/pipper.py
@@ -39,6 +39,9 @@ def parse_req(requirement, extras=None):
         return full_str
 
     req.__str__ = __str__
+    req.extras_name = (
+        req.name + "[" + ",".join(req.extras) + "]" if req.extras else req.name
+    )
     req.extras = frozenset(req.extras)
     return req
 
@@ -160,7 +163,7 @@ def _extract_metadata(wheel_fname):
 
 
 def _get_wheel_requirements(metadata, extras_requested):
-    """Just the strings (name and spec) for my immediate dependencies. Cheap."""
+    """Extract the immediate dependencies from wheel metadata."""
     all_requires = metadata.get("requires_dist", [])
     if not all_requires:
         return []
@@ -214,7 +217,7 @@ def discover_dependencies_and_versions(
     wheel_requirements = _get_wheel_requirements(wheel_metadata, extras_requested)
     wheel_version = wheel_metadata["version"]
     available_versions = (
-        _get_available_versions(req.key, index_url, extra_index_url, pre)
+        _get_available_versions(req.extras_name, index_url, extra_index_url, pre)
         if req.key != "."
         else [wheel_version]
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,8 +140,8 @@ def mock_get_available_versions(package, *args, **kwargs):
     ],
     ids=(
         "pipgrip pipgrip",
-        " requests",
-        " keras (cyclic)",
+        "requests",
+        "keras (cyclic)",
         "--tree keras (cyclic)",
         "keras_preprocessing (underscore)",
     ),

--- a/tests/tests_mixology/package_source.py
+++ b/tests/tests_mixology/package_source.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Hashable, List, Optional
 
 from pipgrip.libs.mixology.constraint import Constraint
+from pipgrip.libs.mixology.package import Package
 from pipgrip.libs.mixology.package_source import PackageSource as BasePackageSource
 from pipgrip.libs.mixology.range import Range
 from pipgrip.libs.mixology.union import Union
@@ -12,6 +13,7 @@ class Dependency:
         self.name = name
         self.constraint = parse_constraint(constraint)
         self.pretty_constraint = constraint
+        self.package = Package(name)
 
     def __str__(self):  # type: () -> str
         return self.pretty_constraint
@@ -85,14 +87,14 @@ class PackageSource(BasePackageSource):
             # VersionUnion
             ranges = [
                 Range(
-                    range.min,
-                    range.max,
-                    range.include_min,
-                    range.include_max,
-                    str(range),
+                    _range.min,
+                    _range.max,
+                    _range.include_min,
+                    _range.include_max,
+                    str(_range),
                 )
-                for range in dependency.constraint.ranges
+                for _range in dependency.constraint.ranges
             ]
             constraint = Union.of(*ranges)
 
-        return Constraint(dependency.name, constraint)
+        return Constraint(dependency.package, constraint)


### PR DESCRIPTION
part 1:
- [x] there is some extras_require down the tree (e.g. at depth 3), which needs to be properly propagated

part 2:
- [x] aiobotocore is root_dep, but other root_dep depends on aiobotocore[boto3]
- [x] aiobotocore[awscli] is root_dep, but other root_dep depends on aiobotocore[boto3]