### PR TITLE
:bug: Handle packages with hyphens for older pip versions

### DIFF
--- a/src/pipgrip/pipper.py
+++ b/src/pipgrip/pipper.py
@@ -251,7 +251,7 @@ def _download_wheel(package, index_url, extra_index_url, pre, cache_dir):
                         else:
                             pkg = canonicalize_name(package)
                             for whl in all_wheels:
-                                if pkg in whl:
+                                if pkg in canonicalize_name(whl):
                                     fname = whl
                                     break
                         break


### PR DESCRIPTION
This allows me to install `jupyterlab-black`.

Closes #20 