### PR TITLE
:sparkles: Add --user option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,16 +118,16 @@ Exhaustive dependency trees without the need to install any packages (at most bu
 ```
 $ pipgrip --tree pipgrip
 
-pipgrip (0.3.0)
+pipgrip (0.4.0)
 ├── anytree (2.8.0)
-│   └── six>=1.9.0 (1.14.0)
+│   └── six>=1.9.0 (1.15.0)
 ├── click (7.1.2)
-├── packaging>=17 (20.3)
+├── packaging>=17 (20.4)
 │   ├── pyparsing>=2.0.2 (2.4.7)
-│   └── six (1.14.0)
-├── pip>=7.1.0 (20.1)
+│   └── six (1.15.0)
+├── pip>=7.1.0 (20.1.1)
 ├── pkginfo>=1.4.2 (1.5.0.1)
-├── setuptools>=38.3 (46.3.1)
+├── setuptools>=38.3 (47.3.1)
 └── wheel (0.34.2)
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Options:
                                 dependencies (WARNING), -vv will show solving
                                 decisions (INFO), -vvv for development (DEBUG).
 
+  --install-user, --user        Pass `--user` option to `pip install` (which
+                                see).  Install to the Python user install
+                                directory for your platform -- typically
+                                ~/.local/, or %APPDATA%\Python on Windows.
+                                (See the Python documentation for
+                                site.USER_BASE for full details.)
+
   -h, --help                    Show this message and exit.
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Usage: pipgrip [OPTIONS] [DEPENDENCIES]...
 Options:
   --install                     Install full dependency tree after resolving.
   -e, --editable                Install a project in editable mode.
+  --user                        Install to the Python user install directory for
+                                your platform -- typically ~/.local/, or
+                                %APPDATA%\Python on Windows. (See the Python
+                                documentation for site.USER_BASE for full
+                                details.)
+
   -r, --requirements-file FILE  Install from the given requirements file. This
                                 option can be used multiple times.
 
@@ -102,13 +108,6 @@ Options:
   -v, --verbose                 Control verbosity: -v will print cyclic
                                 dependencies (WARNING), -vv will show solving
                                 decisions (INFO), -vvv for development (DEBUG).
-
-  --install-user, --user        Pass `--user` option to `pip install` (which
-                                see).  Install to the Python user install
-                                directory for your platform -- typically
-                                ~/.local/, or %APPDATA%\Python on Windows.
-                                (See the Python documentation for
-                                site.USER_BASE for full details.)
 
   -h, --help                    Show this message and exit.
 ```

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -144,10 +144,9 @@ def render_lock(packages, include_dot=True, sort=False):
     "-e", "--editable", is_flag=True, help="Install a project in editable mode.",
 )
 @click.option(
-    "--install-user",
     "--user",
     is_flag=True,
-    help=r"When using --install, pass `--user` option to `pip install` (which see).  Install to the Python user install directory for your platform -- typically ~/.local/, or %APPDATA%\Python on Windows. (See the Python documentation for site.USER_BASE for full details.)",
+    help=r"Install to the Python user install directory for your platform -- typically ~/.local/, or %APPDATA%\Python on Windows. (See the Python documentation for site.USER_BASE for full details.)",
 )
 @click.option(
     "-r",
@@ -228,8 +227,8 @@ def main(
     dependencies,
     requirements_file,
     install,
-    install_user,
     editable,
+    user,
     lock,
     pipe,
     json,
@@ -272,9 +271,6 @@ def main(
         dependencies = []
         for path in requirements_file:
             dependencies += read_requirements(path)
-    if install_user:
-        if not install:
-            raise click.ClickException("--install-user has no effect without --install")
     if editable:
         if not install:
             raise click.ClickException("--editable has no effect without --install")
@@ -282,6 +278,9 @@ def main(
             raise click.ClickException(
                 "--editable does not accept input '{}'".format(" ".join(dependencies))
             )
+    if user:
+        if not install:
+            raise click.ClickException("--user has no effect without --install")
     for dep in dependencies:
         if os.sep in dep:
             raise click.ClickException(
@@ -351,7 +350,7 @@ def main(
                 pre=pre,
                 cache_dir=cache_dir,
                 editable=editable,
-                user=install_user,
+                user=user,
             )
     except (SolverFailure, click.ClickException, CalledProcessError) as exc:
         raise click.ClickException(str(exc))

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -144,6 +144,12 @@ def render_lock(packages, include_dot=True, sort=False):
     "-e", "--editable", is_flag=True, help="Install a project in editable mode.",
 )
 @click.option(
+    "--install-user",
+    "--user",
+    is_flag=True,
+    help=r"When using --install, pass `--user` option to `pip install` (which see).  Install to the Python user install directory for your platform -- typically ~/.local/, or %APPDATA%\Python on Windows. (See the Python documentation for site.USER_BASE for full details.)",
+)
+@click.option(
     "-r",
     "--requirements-file",
     multiple=True,
@@ -222,6 +228,7 @@ def main(
     dependencies,
     requirements_file,
     install,
+    install_user,
     editable,
     lock,
     pipe,
@@ -265,6 +272,9 @@ def main(
         dependencies = []
         for path in requirements_file:
             dependencies += read_requirements(path)
+    if install_user:
+        if not install:
+            raise click.ClickException("--install-user has no effect without --install")
     if editable:
         if not install:
             raise click.ClickException("--editable has no effect without --install")
@@ -341,6 +351,7 @@ def main(
                 pre=pre,
                 cache_dir=cache_dir,
                 editable=editable,
+                user=install_user,
             )
     except (SolverFailure, click.ClickException, CalledProcessError) as exc:
         raise click.ClickException(str(exc))

--- a/src/pipgrip/pipper.py
+++ b/src/pipgrip/pipper.py
@@ -90,7 +90,7 @@ def stream_bash_command(bash_command, echo=False):
     return out
 
 
-def _get_install_args(index_url, extra_index_url, pre, cache_dir, user, editable):
+def _get_install_args(index_url, extra_index_url, pre, cache_dir, editable, user):
     args = [
         sys.executable,
         "-m",
@@ -115,10 +115,10 @@ def _get_install_args(index_url, extra_index_url, pre, cache_dir, user, editable
         ]
     if PIP_VERSION >= [10]:
         args.append("--progress-bar=off")
-    if user:
-        args += ["--user"]
     if editable:
         args += ["--editable"]
+    if user:
+        args += ["--user"]
     return args
 
 
@@ -169,7 +169,7 @@ def install_packages(
 ):
     """Install a list of packages with pip."""
     args = (
-        _get_install_args(index_url, extra_index_url, pre, cache_dir, user, editable)
+        _get_install_args(index_url, extra_index_url, pre, cache_dir, editable, user)
         + packages
     )
 

--- a/src/pipgrip/pipper.py
+++ b/src/pipgrip/pipper.py
@@ -90,7 +90,7 @@ def stream_bash_command(bash_command, echo=False):
     return out
 
 
-def _get_install_args(index_url, extra_index_url, pre, cache_dir, editable):
+def _get_install_args(index_url, extra_index_url, pre, cache_dir, user, editable):
     args = [
         sys.executable,
         "-m",
@@ -115,9 +115,10 @@ def _get_install_args(index_url, extra_index_url, pre, cache_dir, editable):
         ]
     if PIP_VERSION >= [10]:
         args.append("--progress-bar=off")
+    if user:
+        args += ["--user"]
     if editable:
         args += ["--editable"]
-
     return args
 
 
@@ -157,11 +158,18 @@ def _get_wheel_args(index_url, extra_index_url, pre, cache_dir=None):
 
 
 def install_packages(
-    packages, index_url, extra_index_url, pre, cache_dir, editable, constraints=None
+    packages,
+    index_url,
+    extra_index_url,
+    pre,
+    cache_dir,
+    editable,
+    user,
+    constraints=None,
 ):
     """Install a list of packages with pip."""
     args = (
-        _get_install_args(index_url, extra_index_url, pre, cache_dir, editable)
+        _get_install_args(index_url, extra_index_url, pre, cache_dir, user, editable)
         + packages
     )
 


### PR DESCRIPTION
This allows passing `--user` to `pip install`:

```
$ pipgrip --verbose --install --user jupyterlab-black
jupyterlab-black==0.2.1
[...]
Installing collected packages: attrs, backcall, bleach, decorator, zipp, importlib-metadata, ipython-genutils, traitlets, tornado, wcwidth, prompt-toolkit, pexpect, parso, jedi, pygments, setuptools, pickleshare, ipython, ipykernel, jinja2, mistune, nbformat, pandocfilters, prometheus-client, pyparsing, python-dateutil, pyzmq, send2trash, terminado, testpath
Successfully installed attrs-19.3.0 backcall-0.2.0 bleach-3.1.5 decorator-4.4.2 importlib-metadata-1.7.0 ipykernel-5.3.0 ipython-7.16.1 ipython-genutils-0.2.0 jedi-0.17.1 jinja2-2.11.2 mistune-0.8.4 nbformat-5.0.7 pandocfilters-1.4.2 parso-0.7.0 pexpect-4.8.0 pickleshare-0.7.5 prometheus-client-0.8.0 prompt-toolkit-3.0.5 pygments-2.6.1 pyparsing-2.4.7 python-dateutil-2.8.1 pyzmq-19.0.1 send2trash-1.5.0 setuptools-47.3.1 terminado-0.8.3 testpath-0.4.4 tornado-6.0.4 traitlets-4.3.3 wcwidth-0.2.5 zipp-3.1.0
$
```


Without this change:

```
$ pipgrip --verbose --install jupyterlab-black
[...]
Successfully built pandocfilters tornado
Installing collected packages: attrs, backcall, bleach, decorator, zipp, importlib-metadata, tornado, ipython-genutils, traitlets, pickleshare, pygments, parso, jedi, wcwidth, prompt-toolkit, pexpect, setuptools, ipython, ipykernel, jinja2, mistune, nbformat, pandocfilters, prometheus-client, pyparsing, python-dateutil, pyzmq, send2trash, terminado, testpath                                                                  ERROR: Could not install packages due to an EnvironmentError: [Errno 13] Permission denied: '/usr/local/lib/python3.7'                        Consider using the `--user` option or check the permissions.                                                                                                                                                                                                                                                                                                                                                                              Error: Command '['/usr/bin/python', '-m', 'pip', 'install', '--cache-dir', '/home/martin/.cache/pip/wheels/pipgrip', '--index-url', 'https://pypi.org/simple', '--trusted-host', 'pypi.org', '--progress-bar=off', 'jupyterlab-black', '--constraint', '/tmp/tmp3vw71jhq']' returned non-zero exit status 1.                                                                                                                              $
```