### PR TITLE
:ambulance: Get available versions using legacy resolver in pip~=20.3

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -4,6 +4,6 @@ packaging>=17
 pkginfo>=1.4.2
 setuptools>=38.3  # for pkg_resources
 wheel
-pip>=7.1.0  # for --constraint
+pip>=7.1.0,<21  # >=7.1.0 for --constraint, <21 for --use-deprecated legacy-resolver in pipgrip.pipper._get_available_versions
 enum34; python_version=='2.7'
 typing; python_version=='2.7'

--- a/src/pipgrip/pipper.py
+++ b/src/pipgrip/pipper.py
@@ -207,6 +207,10 @@ def _get_available_versions(package, index_url, extra_index_url, pre):
     logger.debug("Finding possible versions for {}".format(package))
     args = _get_wheel_args(index_url, extra_index_url, pre) + [package + "==rubbish"]
 
+    if PIP_VERSION >= [20, 3]:
+        # https://github.com/ddelange/pipgrip/issues/42
+        args += ["--use-deprecated", "legacy-resolver"]
+
     try:
         out = stream_bash_command(args)
     except subprocess.CalledProcessError as err:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def mock_download_wheel(package, *args, **kwargs):
         "keras-preprocessing": "./tests/assets/Keras_Preprocessing-1.1.0-py2.py3-none-any.whl",
         "keras-applications==1.0.4": "./tests/assets/Keras_Applications-1.0.4-py2.py3-none-any.whl",
         "h5py": "./tests/assets/h5py-2.10.0-cp27-cp27m-macosx_10_6_intel.whl",
-        "pip>=7.1.0": "./tests/assets/pip-20.0.2-py2.py3-none-any.whl",
+        "pip<21,>=7.1.0": "./tests/assets/pip-20.0.2-py2.py3-none-any.whl",
     }
     return wheelhouse[package]
 


### PR DESCRIPTION
Fixes #42 

- New resolver doesn't output available versions anymore (could do parsing of the new `-v` output as alternative to this fix)
- Legacy resolver will be deprecated in pip 21 (ref https://github.com/pypa/pip/issues/9187#issuecomment-736000492), so pre-emptively dropping support