### PR TITLE
Add info logger (although not strictly a solving decision)

### DIFF
--- a/src/pipgrip/pipper.py
+++ b/src/pipgrip/pipper.py
@@ -399,6 +399,7 @@ def discover_dependencies_and_versions(
     req = parse_req(package)
     extras_requested = sorted(req.extras)
 
+    logger.info("discovering %s", req)
     wheel_fname = _download_wheel(
         req.__str__(), index_url, extra_index_url, pre, cache_dir
     )


### PR DESCRIPTION
Running `pipgrip -vv` with a lot of root dependencies (big requirements file or so), would result in a long silence (where pipgrip is discovering dependencies for all the root dependencies). This logger makes that apparent.