### PR TITLE
:bug: Fix partial tree rendering

### DIFF
--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -431,6 +431,9 @@ def main(
             exc = None
         except RuntimeError as e:
             # RuntimeError coming from pipgrip.pipper
+            if "Failed to download/build wheel" not in str(e):
+                # only continue handling expected RuntimeErrors
+                raise
             solution = solver.solution
             exc = e
 
@@ -456,10 +459,7 @@ def main(
         else:
             # a RuntimeError occurred
             # log a partial tree (failed download/build) if the RuntimeError ends with the culptit pip_string
-            culprit_package = str(exc).split()[-1]
-            if culprit_package not in rendered_tree:
-                # only continue handling expected RuntimeErrors
-                raise exc
+            culprit_package = Package(str(exc).split()[-1]).name
 
             rendered_tree = rendered_tree.replace(
                 "{} (undecided)".format(culprit_package),


### PR DESCRIPTION
Properly extract the package name from the error message containing a version: `aliyun-python-sdk-core-v3==2.13.31` ref #77 

```
$ pipgrip knack oss2
ERROR: Downloading/building wheel for aliyun-python-sdk-core-v3==2.13.31 failed with output:
Collecting aliyun-python-sdk-core-v3==2.13.31
  Using cached aliyun-python-sdk-core-v3-2.13.31.tar.gz (440 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
  WARNING: Generating metadata for package aliyun-python-sdk-core-v3 produced metadata for project name aliyun-python-sdk-core. Fix your #egg=aliyun-python-sdk-core-v3 fragments.
Discarding https://files.pythonhosted.org/packages/13/63/52c2fc00ce2334cef2051548215ae27878b187b819f01876539608752837/aliyun-python-sdk-core-v3-2.13.31.tar.gz#sha256=427f27f420d3d88577788f703e2ee1b2f804e9ce645a2e175dafe9c56d339b3c (from https://pypi.org/simple/aliyun-python-sdk-core-v3/): Requested aliyun-python-sdk-core from https://files.pythonhosted.org/packages/13/63/52c2fc00ce2334cef2051548215ae27878b187b819f01876539608752837/aliyun-python-sdk-core-v3-2.13.31.tar.gz#sha256=427f27f420d3d88577788f703e2ee1b2f804e9ce645a2e175dafe9c56d339b3c has inconsistent name: filename has 'aliyun-python-sdk-core-v3', but metadata has 'aliyun-python-sdk-core'
ERROR: Could not find a version that satisfies the requirement aliyun-python-sdk-core-v3==2.13.31 (from versions: 2.3.2, 2.3.3, 2.3.4, 2.3.5, 2.3.6, 2.3.7, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.4.4, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.5.4, 2.5.5, 2.7.2, 2.8.2, 2.8.3, 2.8.4, 2.8.5, 2.8.6, 2.8.7, 2.8.8, 2.8.9, 2.9.0, 2.9.1, 2.9.3, 2.9.4, 2.10.1, 2.11.0, 2.11.1, 2.11.4, 2.11.5, 2.12.1, 2.13.0, 2.13.3, 2.13.8, 2.13.9, 2.13.10, 2.13.11, 2.13.31, 2.13.32, 2.13.33)
ERROR: No matching distribution found for aliyun-python-sdk-core-v3==2.13.31
ERROR: Failed to download/build wheel for aliyun-python-sdk-core-v3==2.13.31. Best guess PartialSolution tree after the last solving decision (Package("six"), <Version 1.16.0>):
knack (0.9.0)
├── argcomplete (undecided)
├── jmespath (1.0.0)
├── pygments (undecided)
├── pyyaml (6.0)
└── tabulate (0.8.9)
oss2 (2.13.1)
├── aliyun-python-sdk-core-v3>=2.5.5 (undecided)
├── aliyun-python-sdk-kms>=2.4.1 (2.15.0)
│   └── aliyun-python-sdk-core>=2.11.5 (2.11.5)
│       └── pycryptodome>=3.4.7 (undecided)
├── crcmod>=1.7 (1.7)
├── pycryptodome>=3.4.7 (undecided)
├── requests!=2.9.0 (undecided)
└── six (1.16.0)
Error: Failed to download/build wheel for aliyun-python-sdk-core-v3==2.13.31
```