### PR TITLE
:bug: Disallow open ranges combined with vcs

### DIFF
--- a/src/pipgrip/libs/mixology/range.py
+++ b/src/pipgrip/libs/mixology/range.py
@@ -262,6 +262,15 @@ class Range(object):
         return self.include_max and not other.include_max
 
     def is_strictly_lower(self, other):  # type: (Range) -> bool
+        if (
+            not self.is_any()
+            and not other.is_any()
+            and self.is_vcs_version() + other.is_vcs_version() == 1
+        ):
+            # internally, vcs strings are hashed and becomes a (very high) major version
+            # so another requirement without a max would not conflict although it should
+            return True
+
         if self.max is None or other.min is None:
             return False
 
@@ -294,6 +303,9 @@ class Range(object):
             and self.include_min
             and self.include_max
         )
+
+    def is_vcs_version(self):  # type: () -> bool
+        return self.is_single_version() and self._min.is_vcs()
 
     def __eq__(self, other):
         if not isinstance(other, Range):

--- a/src/pipgrip/libs/mixology/term.py
+++ b/src/pipgrip/libs/mixology/term.py
@@ -152,7 +152,7 @@ class Term(object):
         elif self.is_positive() != other.is_positive():
             to_return = self if self.is_positive() else other
         else:
-            to_return = Term(Constraint(self.package, EmptyRange()))
+            to_return = Term(Constraint(self.package, EmptyRange()), self.is_positive())
 
         return to_return
 

--- a/src/pipgrip/libs/semver/version.py
+++ b/src/pipgrip/libs/semver/version.py
@@ -229,10 +229,13 @@ class Version(VersionRange):
 
         return Version(major, minor, patch, rest, pre, build, text)
 
-    def is_any(self):
+    def is_vcs(self):  # type: () -> bool
+        return str(self._major) not in self._text
+
+    def is_any(self):  # type: () -> bool
         return False
 
-    def is_empty(self):
+    def is_empty(self):  # type: () -> bool
         return False
 
     def is_prerelease(self):  # type: () -> bool

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,10 @@ def mock_download_wheel(package, *args, **kwargs):
         "six": "./tests/assets/six-1.13.0-py2.py3-none-any.whl",
         "wheel": "./tests/assets/wheel-0.33.6-py2.py3-none-any.whl",
         "pyparsing>=2.0.2": "./tests/assets/pyparsing-2.4.6-py2.py3-none-any.whl",
+        "requests": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
         "requests==2.22.0": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
+        "requests>=2.22.0": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
+        "requests<=2.22.0": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
         "urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1": "./tests/assets/urllib3-1.25.7-py2.py3-none-any.whl",
         "urllib3==1.25.7": "./tests/assets/urllib3-1.25.7-py2.py3-none-any.whl",
         "idna<2.9,>=2.5": "./tests/assets/idna-2.8-py2.py3-none-any.whl",
@@ -255,7 +258,7 @@ def invoke_patched(func, arguments, monkeypatch, **kwargs):
             ["keras-preprocessing==1.1.0", "six==1.13.0", "numpy==1.16.6"],
         ),
         (
-            ["requests@git+https://github.com/psf/requests"],
+            ["requests", "requests@git+https://github.com/psf/requests"],
             [
                 "requests @ git+https://github.com/psf/requests",
                 "certifi==2019.11.28",
@@ -290,7 +293,7 @@ def invoke_patched(func, arguments, monkeypatch, **kwargs):
         "keras_preprocessing (underscore)",
         "-r",
         "environment marker",
-        "vcs",
+        "vcs with unpinned version",
         "vcs with extras",
     ),
 )
@@ -356,6 +359,9 @@ def test_correct_options(arguments, monkeypatch):
         (["-e", "click"]),
         (["--reverse-tree", "click"]),
         (["../."]),
+        (["requests==2.22.0", "requests@git+https://github.com/psf/requests"]),
+        (["requests>=2.22.0", "requests@git+https://github.com/psf/requests"]),
+        (["requests<=2.22.0", "requests@git+https://github.com/psf/requests"]),
     ],
 )
 def test_incorrect_options(arguments, monkeypatch):


### PR DESCRIPTION
`pipgrip requests>=2.22.0 requests@git+https://github.com/psf/requests`

used to finish successfully, now it conflicts (as pip does)