### PR TITLE
Update anytree version requirement

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-anytree
+anytree>=4.2.1
 click>=7
 packaging>=17
 pkginfo>=1.4.2,<1.8  # ref ddelange/pipgrip#68


### PR DESCRIPTION
Anytree version 4.2.0 and below do not work due to missing either anytree.iterators or anytree.exporters:

<img width="892" alt="image" src="https://user-images.githubusercontent.com/22552445/170724796-17ce6131-d049-4485-8d49-5e816f6bab2b.png">

4.2.1 works for pipgrip
<img width="890" alt="image" src="https://user-images.githubusercontent.com/22552445/170724885-1c360eb1-fcbf-4582-8eaf-f8a4f39f8491.png">

