### PR TITLE
:pencil2: Fix help text for --tree-json-exact flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Options:
                                 dependency tree. Use --tree-json instead for a
                                 simplified JSON dependency tree (requirement
                                 strings as keys, dependencies as values), or
-                                --json-tree-exact for exact pins as keys.
+                                --tree-json-exact for exact pins as keys.
 
   --tree-ascii                  Output human readable dependency tree with ASCII
                                 tree markers.

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -267,7 +267,7 @@ def render_lock(packages, include_dot=True, sort=False):
 @click.option(
     "--tree",
     is_flag=True,
-    help="Output human readable dependency tree (top-down). Combine with --json for a detailed nested JSON dependency tree. Use --tree-json instead for a simplified JSON dependency tree (requirement strings as keys, dependencies as values), or --json-tree-exact for exact pins as keys.",
+    help="Output human readable dependency tree (top-down). Combine with --json for a detailed nested JSON dependency tree. Use --tree-json instead for a simplified JSON dependency tree (requirement strings as keys, dependencies as values), or --tree-json-exact for exact pins as keys.",
 )
 @click.option(
     "--tree-ascii",


### PR DESCRIPTION
Thanks for the great tool, love it so far 😄 please keep it up and running 🚀 

Adjusted the help text to reflect the correct name of the `--tree-json-exact` flag.