### PR TITLE
:bug: Fix handling of unions of package extras

### DIFF
--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -457,6 +457,9 @@ def main(
 
         if exc is None:
             if "(undecided)" in rendered_tree:
+                logger.error(
+                    "Unexpected partial solution encountered:\n{}".format(rendered_tree)
+                )
                 raise RuntimeError(
                     "Unexpected partial solution encountered, not all packages have decisions"
                 )

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -137,13 +137,19 @@ def _recurse_dependencies(
         if resolved_version == "undecided":
             continue
 
-        packages[(name, str(resolved_version))] = _recurse_dependencies(
+        deeper = _recurse_dependencies(
             source,
             decision_packages,
             source.dependencies_for(dep.package, resolved_version),
             tree_root,
             tree_node,
         )
+        key = (name, str(resolved_version))
+        # mimic semantics of DefaultOrderedDict
+        if key in packages:
+            packages[key].update(deeper)
+        else:
+            packages[key] = deeper
     return packages
 
 

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -108,6 +108,9 @@ def _recurse_dependencies(
         name = dep.name
         resolved_version = decision_packages.get(dep.package) or "undecided"
 
+        # recreate package, to overwrite internal extras which might be a union including other deps' extras
+        dep.package = Package(dep.pip_string)
+
         tree_node = Node(
             name,
             version=str(resolved_version),

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -108,9 +108,6 @@ def _recurse_dependencies(
         name = dep.name
         resolved_version = decision_packages.get(dep.package) or "undecided"
 
-        # recreate package, to overwrite internal extras which might be a union including other deps' extras
-        dep.package = Package(dep.pip_string)
-
         tree_node = Node(
             name,
             version=str(resolved_version),

--- a/src/pipgrip/libs/mixology/constraint.py
+++ b/src/pipgrip/libs/mixology/constraint.py
@@ -33,13 +33,7 @@ class Constraint(object):
         return self.__class__(self.package, new_constraint)
 
     def allows_all(self, other):  # type: (Constraint) -> bool
-        if not self.constraint.allows_all(other.constraint):
-            return False
-        if not self.package.req.extras.union(other.package.req.extras):
-            # if both come without extras, only look at version constraints
-            return True
-        # otherwise additionally check whether some extras are unaccounted for
-        return other.package.req.extras.issuperset(self.package.req.extras)
+        return self.constraint.allows_all(other.constraint)
 
     def allows_any(self, other):  # type: (Constraint) -> bool
         return self.constraint.allows_any(other.constraint)

--- a/src/pipgrip/libs/mixology/constraint.py
+++ b/src/pipgrip/libs/mixology/constraint.py
@@ -33,7 +33,13 @@ class Constraint(object):
         return self.__class__(self.package, new_constraint)
 
     def allows_all(self, other):  # type: (Constraint) -> bool
-        return self.constraint.allows_all(other.constraint)
+        if not self.constraint.allows_all(other.constraint):
+            return False
+        if not self.package.req.extras.union(other.package.req.extras):
+            # if both come without extras, only look at version constraints
+            return True
+        # otherwise additionally check whether some extras are unaccounted for
+        return other.package.req.extras.issuperset(self.package.req.extras)
 
     def allows_any(self, other):  # type: (Constraint) -> bool
         return self.constraint.allows_any(other.constraint)
@@ -101,3 +107,6 @@ class Constraint(object):
 
     def __str__(self):
         return self.to_string()
+
+    def __repr__(self):
+        return "<Constraint {}>".format(str(self))

--- a/src/pipgrip/libs/mixology/package.py
+++ b/src/pipgrip/libs/mixology/package.py
@@ -24,16 +24,16 @@ class Package(object):
         return self._req
 
     def __eq__(self, other):  # type: () -> bool
-        return str(other) == self.name
+        return str(other) == str(self)
 
     def __ne__(self, other):  # type: () -> bool
         return not self.__eq__(other)
 
     def __str__(self):  # type: () -> str
-        return self._name
+        return self.name
 
     def __repr__(self):  # type: () -> str
         return 'Package("{}")'.format(self.req.extras_name)
 
     def __hash__(self):
-        return hash(self.name)
+        return hash(str(self))

--- a/src/pipgrip/libs/mixology/partial_solution.py
+++ b/src/pipgrip/libs/mixology/partial_solution.py
@@ -199,7 +199,14 @@ class PartialSolution:
     def relation(self, term):  # type: (Term) -> SetRelation
         positive = self._positive.get(term.package)
         if positive is not None:
-            return positive.relation(term)
+            relation = positive.relation(term)
+            if (
+                relation is not SetRelation.OVERLAPPING
+                and not term.package.req.extras.issubset(positive.package.req.extras)
+            ):
+                # force further inspection when term's extras are not in current solution
+                return SetRelation.OVERLAPPING
+            return relation
 
         by_ref = self._negative.get(term.package)
         if by_ref is None:

--- a/src/pipgrip/libs/mixology/term.py
+++ b/src/pipgrip/libs/mixology/term.py
@@ -142,10 +142,14 @@ class Term(object):
                     self.constraint.union(other.constraint), False
                 )
             if to_return is not None:
-                to_return._constraint._package._req = parse_req(
-                    to_return.constraint.package.req.__str__(),
-                    extras=self.constraint.package.req.extras
-                    | other.constraint.package.req.extras,
+                to_return._constraint._package = Package(
+                    str(
+                        parse_req(
+                            to_return.constraint.package.req.__str__(),
+                            extras=self.constraint.package.req.extras
+                            | other.constraint.package.req.extras,
+                        )
+                    )
                 )
                 to_return._package = self.constraint.package
 

--- a/src/pipgrip/libs/mixology/version_solver.py
+++ b/src/pipgrip/libs/mixology/version_solver.py
@@ -314,6 +314,7 @@ class VersionSolver:
 
     def _next_term_to_try(self):  # type: () -> Optional[Term]
         unsatisfied = self._solution.unsatisfied
+        logger.debug("unsatisfied: %s", unsatisfied)
         if not unsatisfied:
             return
 

--- a/src/pipgrip/libs/mixology/version_solver.py
+++ b/src/pipgrip/libs/mixology/version_solver.py
@@ -154,15 +154,11 @@ class VersionSolver:
                 # can deduce from it.
                 return
             elif relation == SetRelation.OVERLAPPING:
-                # If more than one term is inconclusive, we can't deduce anything about
-                # incompatibility.
-                if unsatisfied is not None:
-                    return
-
                 # If exactly one term in incompatibility is inconclusive, then it's
                 # almost satisfied and [term] is the unsatisfied term. We can add the
                 # inverse of the term to _solution.
                 unsatisfied = term
+                break
 
         # If *all* terms in incompatibility are satisfied by _solution, then
         # incompatibility is satisfied and we have a conflict.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,7 @@ def mock_download_wheel(package, *args, **kwargs):
         "requests[socks]@ git+https://github.com/psf/requests": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
         "requests@ git+https://github.com/psf/requests": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
         "requests[socks]": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
+        "requests[socks]==2.22.0": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
         "pysocks!=1.5.7,>=1.5.6": "./tests/assets/PySocks-1.7.1-py3-none-any.whl",
     }
     return wheelhouse[package]
@@ -291,6 +292,17 @@ def invoke_patched(func, arguments, monkeypatch, **kwargs):
                 "urllib3==1.25.7",
             ],
         ),
+        (
+            ["requests", "requests[socks]==2.22.0"],
+            [
+                "requests==2.22.0",
+                "certifi==2019.11.28",
+                "chardet==3.0.4",
+                "idna==2.8",
+                "pysocks==1.7.1",
+                "urllib3==1.25.7",
+            ],
+        ),
     ],
     ids=(
         "pipgrip pipgrip",
@@ -309,6 +321,7 @@ def invoke_patched(func, arguments, monkeypatch, **kwargs):
         "vcs with unpinned version",
         "vcs with extras",
         "multiple occurrences different extras",
+        "multiple occurrences different extras (symmetrical)",
     ),
 )
 def test_solutions(arguments, expected, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ def mock_download_wheel(package, *args, **kwargs):
         "pip>=7.1.0": "./tests/assets/pip-20.0.2-py2.py3-none-any.whl",
         "requests[socks]@ git+https://github.com/psf/requests": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
         "requests@ git+https://github.com/psf/requests": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
+        "requests[socks]": "./tests/assets/requests-2.22.0-py2.py3-none-any.whl",
         "pysocks!=1.5.7,>=1.5.6": "./tests/assets/PySocks-1.7.1-py3-none-any.whl",
     }
     return wheelhouse[package]
@@ -58,6 +59,7 @@ def mock_get_available_versions(package, *args, **kwargs):
         "wheel": ["0.33.6"],
         "pyparsing": ["2.4.6"],
         "requests": ["2.22.0"],
+        "requests[socks]": ["2.22.0", "2.23.0"],
         "urllib3": ["1.25.7"],
         "idna": ["2.8"],
         "chardet": ["3.0.4"],
@@ -278,6 +280,17 @@ def invoke_patched(func, arguments, monkeypatch, **kwargs):
                 "urllib3==1.25.7",
             ],
         ),
+        (
+            ["requests[socks]", "requests==2.22.0"],
+            [
+                "requests==2.22.0",
+                "certifi==2019.11.28",
+                "chardet==3.0.4",
+                "idna==2.8",
+                "pysocks==1.7.1",
+                "urllib3==1.25.7",
+            ],
+        ),
     ],
     ids=(
         "pipgrip pipgrip",
@@ -295,6 +308,7 @@ def invoke_patched(func, arguments, monkeypatch, **kwargs):
         "environment marker",
         "vcs with unpinned version",
         "vcs with extras",
+        "multiple occurrences different extras",
     ),
 )
 def test_solutions(arguments, expected, monkeypatch):


### PR DESCRIPTION
Fixes #96 

These used to fail:

```console
$ pipgrip --tree --max-depth=2 smart-open[azure]~=6.0 smart-open[s3]==6.1.0
smart-open[azure]~=6.0 (6.1.0)
├── azure-common (1.1.28)
├── azure-core (1.25.1)
└── azure-storage-blob (12.13.1)
smart-open[s3]==6.1.0 (6.1.0)
└── boto3 (1.24.66)
$ pipgrip --tree --max-depth=3 smart-open~=6.0 pypicloud[azure-blob]~=1.3.9
smart-open~=6.0 (6.1.0)
pypicloud[azure-blob]~=1.3.9 (1.3.10)
├── smart-open[azure]>=6.1.0 (6.1.0)
│   ├── azure-common (1.1.28)
│   ├── azure-core (1.25.1)
│   └── azure-storage-blob (12.13.1)
├── smart-open[http,s3] (6.1.0)
│   ├── boto3 (1.24.66)
│   └── requests (2.28.1)
...
```