### PR TITLE
:zap: Use more threads by default

### DIFF
--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -324,7 +324,7 @@ def render_lock(packages, include_dot=True, sort=False):
     "--threads",
     type=click.INT,
     envvar="PIPGRIP_THREADS",
-    default=cpu_count(),
+    default=min(8, cpu_count()),
     help="Maximum amount of threads to use for running concurrent pip subprocesses.",
 )
 @click.option(


### PR DESCRIPTION
Empirically tested on a realistic scenario using Github CI (1physical/2logical core machibe), this turned out to be a sensible default:
- 2 threads 5:30
- 4 threads 3:30
- 8 threads 2:30
- 16 threads 2:30