### PR TITLE
:bug: Fix a rare case of infinite loop related to extras

### DIFF
--- a/src/pipgrip/libs/mixology/partial_solution.py
+++ b/src/pipgrip/libs/mixology/partial_solution.py
@@ -212,7 +212,7 @@ class PartialSolution:
         if positive is not None:
             relation = positive.relation(term)
             if (
-                relation is not SetRelation.OVERLAPPING
+                relation is SetRelation.DISJOINT
                 and not term.package.req.extras.issubset(positive.package.req.extras)
             ):
                 # force further inspection when term's extras are not in current solution


### PR DESCRIPTION
found via `pipgrip -vv --tree kserve==0.10.0rc1 mxnet==1.9.1 autogluon-text==0.6.1 'aiobotocore[awscli]<=2.2.0' aioboto3`

would cause an infinite loop of

```
INFO: derived: aiobotocore[boto3] (==2.4.1)
INFO: derived: aiobotocore[awscli] (<=2.2.0)
```

instead of recognizing this is illegal. now it correctly starts searching versions of `aiobotocore[awscli,boto3]`