### PR TITLE
:zap: Prepare for metadata-only resolves

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,14 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
+      if: matrix.python-version != '2.7'
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Set up Python 2
+      if: matrix.python-version == '2.7'
+      run: sudo apt-get install python2.7-dev
 
     - name: Pip cache
       uses: actions/cache@v2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 
 import pipgrip.pipper
 from pipgrip.cli import flatten, main
-from pipgrip.pipper import _download_wheel
+from pipgrip.pipper import PIP_VERSION, _download_wheel
 
 self_wheel = _download_wheel(".", None, None, None, "./tests/assets")
 
@@ -113,6 +113,11 @@ def invoke_patched(func, arguments, monkeypatch, **kwargs):
         pipgrip.pipper,
         "_download_wheel",
         mock_download_wheel,
+    )
+    monkeypatch.setattr(
+        pipgrip.pipper,
+        "PIP_VERSION",
+        [22, 0],  # to circumvent _get_package_report
     )
     monkeypatch.setattr(
         pipgrip.pipper,

--- a/tests/test_pipper.py
+++ b/tests/test_pipper.py
@@ -285,6 +285,17 @@ def test_get_package_report(package, pip_output, expected, monkeypatch):
         == expected
     )
 
+    assert (
+        _get_package_report(
+            package,
+            None,
+            None,
+            False,
+            None,
+        )
+        == expected
+    )
+
 
 @pytest.mark.parametrize(
     "package, pre, pip_output, expected",


### PR DESCRIPTION
With a lot of excitement, adding support for pip's new --dry-run --report functionality.

Current pip (23.2.1) will still unnecessarily build the wheel when there's metadata available. This will be fixed hopefully soon ref https://github.com/pypa/pip/pull/12186#issuecomment-1671050968.

That PR will bring the full speed-up of not having to build/download wheels anymore for wheels uploaded to PyPI after the [relevant](https://github.com/pypi/warehouse/issues/8254#issuecomment-1544557695) changes were deployed on warehouse side (~2023.06):

Closes https://github.com/ddelange/pipgrip/issues/40 🎉

Try it out now:
```
$ pip install 'pip @ https://github.com/cosmicexplorer/pip/archive/refs/heads/metadata_only_resolve_no_whl.zip'
$ pipgrip tensorflow
```