### PR TITLE
:construction_worker: Add Dependabot config to autoupdate GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
CI is currently throwing deprecation warnings due to old action versions ([recent example](https://github.com/ddelange/pipgrip/actions/runs/6690468989)). For example, `actions/checkout@v2` needs to be upgraded.

Rather than updating the versions once, this PR introduces a Dependabot config to autoupdate actions each month via a PR (if any updates exist).

Note that if this PR merges, Dependabot will immediately submit a PR to update the actions.