### PR TITLE
Update pre-commit URLs and hook/`additional_dependencies` versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,19 +7,19 @@ repos:
         exclude: .*/tests/.*
         additional_dependencies: ['gibberish-detector']
 
--   repo: https://github.com/psf/black
+-   repo: https://github.com/psf/black-pre-commit-mirror
     # when updating this version, also update blacken-docs hook below
     rev: 23.10.0
     hooks:
     -   id: black
 
--   repo: https://github.com/asottile/blacken-docs
+-   repo: https://github.com/adamchainz/blacken-docs
     rev: v1.12.1
     hooks:
     -   id: blacken-docs
         additional_dependencies: ['black==23.10.0']
 
--   repo: https://github.com/timothycrosley/isort
+-   repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:
     -   id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,15 +9,15 @@ repos:
 
 -   repo: https://github.com/psf/black-pre-commit-mirror
     # when updating this version, also update blacken-docs hook below
-    rev: 23.10.0
+    rev: 23.11.0
     hooks:
     -   id: black
 
 -   repo: https://github.com/adamchainz/blacken-docs
-    rev: v1.12.1
+    rev: 1.16.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: ['black==23.10.0']
+        additional_dependencies: ['black==23.11.0']
 
 -   repo: https://github.com/PyCQA/isort
     rev: 5.12.0
@@ -32,10 +32,10 @@ repos:
             # 'darglint~=1.5.4',
             'flake8-absolute-import~=1.0',
             'flake8-blind-except~=0.2.1',
-            'flake8-builtins~=1.5.3',
-            'flake8-cognitive-complexity==0.1.0',
-            'flake8-comprehensions~=3.8.0',
-            # 'flake8-docstrings~=1.5.0',
+            'flake8-builtins~=2.2.0',
+            'flake8-cognitive-complexity~=0.1.0',
+            'flake8-comprehensions~=3.14.0',
+            # 'flake8-docstrings~=1.7.0',
             'flake8-logging-format~=0.9.0',
             'flake8-mutable~=1.2.0',
             'flake8-print~=4.0.0',
@@ -47,7 +47,7 @@ repos:
         ]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: mixed-line-ending
         args: ['--fix=lf']


### PR DESCRIPTION
This PR introduces the following:

* Update `isort` and `blacken-docs` URLs because their repos are now redirects
* Update `black` URL to use the mypyc-compiled version which is ~2x faster ([doc reference](https://black.readthedocs.io/en/stable/integrations/source_version_control.html))
* Run `pre-commit autoupdate` and `upadup` to update hook and `additional_dependencies` versions

After the changes, `pre-commit run -a` reported no new issues found in the codebase.