### PR TITLE
:construction_worker: Lint GitHub workflows and dependabot yamls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: GH
 on:
   pull_request:
   push:
-    branches: master
+    branches: [master]
   release:
     types: [released, prereleased]
   workflow_dispatch:  # allows running workflow manually from the Actions tab

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,9 @@ repos:
     -   id: check-xml
     -   id: check-yaml
     -   id: debug-statements
+
+-   repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.27.1
+    hooks:
+    -   id: check-dependabot
+    -   id: check-github-workflows


### PR DESCRIPTION
This PR introduces the following:

* Add a pre-commit hook to validate the Dependabot config and GitHub workflow files match schema definitions
* Fix a schema issue in the `main.yml` file (`branches` must be an array of strings).