### PR TITLE
Fix the current test suite on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,45 @@ jobs:
       run: |
         codecov
 
+  # TODO: This should be combined with the CI job above.
+  CI-Windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Pip cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements/*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        pip install -U pip setuptools wheel codecov
+        pip install -r requirements/ci.txt
+        pip install -e .
+
+    - name: Test
+      run: python -m pytest tests/
+
+    - name: Codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        codecov
+
   CD:
     needs: CI
     if: github.event_name == 'release'

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,6 +1,8 @@
 pre-commit~=2.9 ; python_version >= "3.6"
 pytest
-pytest-cov~=2.8
-pytest-env~=0.6
+pytest-cov~=4.1 ; python_version >= "3.7"
+pytest-cov==2.12.0; python_version < "3.7"  # Old Python support
+pytest-env~=1.1.1 ; python_version >= "3.8"
+pytest-env==0.6.2 ; python_version < "3.8"  # Old Python support
 testfixtures~=6.10
 pkginfo<1.8  # still required because legacy py2 code is also tested on py3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -s --strict -vv --tb=long --cache-clear --maxfail=1 --cov=pipgrip --cov-report=term --cov-report=html --cov-branch --no-cov-on-fail
+addopts = -s --strict-markers -vv --tb=long --cache-clear --maxfail=1 --cov=pipgrip --cov-report=term --cov-report=html --cov-branch --no-cov-on-fail
 
 [isort]
 profile = black


### PR DESCRIPTION
_Work in progress_

Currently, this PR simply adds Windows as a CI target platform. The test suite has a single error on Python 3.12 on Windows but pipgrip is crashing for multiple reasons when I try to run it, so making sure the test suite runs on Windows is step 1.