### PR TITLE
:children_crossing: Improve support for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         pip install .
 
     - name: Test
-      run: pipgrip --tree pipgrip
+      run: pipgrip -vvv --tree pipgrip
 
   CD:
     needs: [CI, windows-smoketest]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,8 +68,28 @@ jobs:
       run: |
         codecov
 
+  windows-smoketest:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+
+    - name: Install
+      run: |
+        pip install -U pip setuptools wheel
+        pip install .
+
+    - name: Test
+      run: pipgrip --tree pipgrip
+
   CD:
-    needs: CI
+    needs: [CI, windows-smoketest]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -393,7 +393,7 @@ def main(
         tree_json = True
 
     # Unicode tree markers are unsupported on Windows even by click.echo
-    if tree and platform.system() == "Windows":
+    if tree and platform.system() == "Windows":  # pragma: no cover
         tree_ascii = True
 
     if max_depth == 0 or max_depth < -1:

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -164,7 +164,7 @@ def build_tree(source, decision_packages):
 
 
 def render_tree(tree_root, max_depth, tree_ascii=False):
-    if sys.getfilesystemencoding() == 'cp1252':
+    if sys.getfilesystemencoding() == "cp1252":
         # Windows' cp1252 encoding does not supports anytree's unicode markers
         tree_ascii = True
     style = AsciiStyle() if tree_ascii else ContStyle()

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -2,7 +2,6 @@ import io
 import logging
 import os
 import re
-import sys
 from collections import OrderedDict
 from functools import partial
 from json import dumps

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import os
+import platform
 import re
 from collections import OrderedDict
 from functools import partial
@@ -390,6 +391,10 @@ def main(
         tree = True
     elif tree_json_exact:
         tree_json = True
+
+    # Unicode tree markers are unsupported on Windows even by click.echo
+    if tree and platform.system() == "Windows":
+        tree_ascii = True
 
     if max_depth == 0 or max_depth < -1:
         raise click.ClickException("Illegal --max_depth selected: {}".format(max_depth))

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -165,7 +165,7 @@ def build_tree(source, decision_packages):
 def render_tree(tree_root, max_depth, tree_ascii=False):
     # Windows' cp1252 encoding does not supports anytree's unicode markers.
     # Even in Github Actions where the windows runner has PYTHONUTF8 mode enabled,
-    # `if sys.getfilesystemencoding() == "cp1252":` check is insufficient and the 
+    # `if sys.getfilesystemencoding() == "cp1252":` check is insufficient and the
     # error is still raised in CI.
     # Hence disabling unicode trees altogether for Windows.
     # ref https://github.com/pallets/click/issues/2121#issuecomment-1312773882

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -164,8 +164,13 @@ def build_tree(source, decision_packages):
 
 
 def render_tree(tree_root, max_depth, tree_ascii=False):
-    if sys.getfilesystemencoding() == "cp1252":
-        # Windows' cp1252 encoding does not supports anytree's unicode markers
+    # Windows' cp1252 encoding does not supports anytree's unicode markers.
+    # Even in Github Actions where the windows runner has PYTHONUTF8 mode enabled,
+    # `if sys.getfilesystemencoding() == "cp1252":` check is insufficient and the 
+    # error is still raised in CI.
+    # Hence disabling unicode trees altogether for Windows.
+    # ref https://github.com/pallets/click/issues/2121#issuecomment-1312773882
+    if click.utils.WIN:  # pragma: no cover
         tree_ascii = True
     style = AsciiStyle() if tree_ascii else ContStyle()
     output = []

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -1,8 +1,8 @@
 import io
 import logging
 import os
-import platform
 import re
+import sys
 from collections import OrderedDict
 from functools import partial
 from json import dumps
@@ -164,6 +164,9 @@ def build_tree(source, decision_packages):
 
 
 def render_tree(tree_root, max_depth, tree_ascii=False):
+    if sys.getfilesystemencoding() == 'cp1252':
+        # Windows' cp1252 encoding does not supports anytree's unicode markers
+        tree_ascii = True
     style = AsciiStyle() if tree_ascii else ContStyle()
     output = []
     for child in tree_root.children:
@@ -391,10 +394,6 @@ def main(
         tree = True
     elif tree_json_exact:
         tree_json = True
-
-    # Unicode tree markers are unsupported on Windows even by click.echo
-    if tree and platform.system() == "Windows":  # pragma: no cover
-        tree_ascii = True
 
     if max_depth == 0 or max_depth < -1:
         raise click.ClickException("Illegal --max_depth selected: {}".format(max_depth))

--- a/src/pipgrip/pipper.py
+++ b/src/pipgrip/pipper.py
@@ -72,13 +72,20 @@ def stream_bash_command(args, echo=False):
     """Mimic subprocess.run, while processing the command output in real time."""
     # https://gist.github.com/ddelange/6517e3267fb74eeee804e3b1490b1c1d
     out = []
+    env = os.environ.copy()
+    # Enable Python's UTF-8 mode.
+    env["PYTHONUTF8"] = "1"
     process = subprocess.Popen(  # can use with-statement as of py 3.2
-        args, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
     )
     for line in process.stdout:
-        out.append(line)
+        decoded_line = line.decode("utf-8", errors="replace")
+        out.append(decoded_line)
         if echo:
-            _echo(line[:-1])
+            _echo(decoded_line.rstrip())
     process.stdout.close()
     out = "".join(out)
     retcode = process.wait()


### PR DESCRIPTION
Windows doesn't consistently use UTF-8 as the default system encoding.

Enabling universal newlines causes Python to decode STDOUT using the default system encoding, which may not be UTF-8 compatible. (On my PC, running Windows 10 Home, the default encoding is `cp1252`.) In addition, when pip is executed via `subprocess`, it may crash when attempting to write output containing Unicode characters.

To resolve these issues, Python's UTF-8 mode (available in 3.7+) is enabled via an environment variable, universal newlines are disabled, and STDOUT is read and explicitly decoded as UTF-8.

No new test cases are introduced, but I'm now able to successfully run pipgrip on Windows.