### PR TITLE
:children_crossing: Support Python UTF-8 mode on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,12 @@ jobs:
         pip install -U pip setuptools wheel
         pip install .
 
-    - name: Test
+    - name: Test (ascii)
+      run: pipgrip -vvv --tree pipgrip
+
+    - name: Test (unicode)
+      env:
+        PYTHONUTF8: '1'
       run: pipgrip -vvv --tree pipgrip
 
   CD:

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -2,6 +2,7 @@ import io
 import logging
 import os
 import re
+import sys
 from collections import OrderedDict
 from functools import partial
 from json import dumps
@@ -163,13 +164,11 @@ def build_tree(source, decision_packages):
 
 
 def render_tree(tree_root, max_depth, tree_ascii=False):
-    # Windows' cp1252 encoding does not supports anytree's unicode markers.
-    # Even in Github Actions where the windows runner has PYTHONUTF8 mode enabled,
-    # `if sys.getfilesystemencoding() == "cp1252":` check is insufficient and the
-    # error is still raised in CI.
-    # Hence disabling unicode trees altogether for Windows.
-    # ref https://github.com/pallets/click/issues/2121#issuecomment-1312773882
-    if click.utils.WIN:  # pragma: no cover
+    # click.echo on Windows' cp1252 encoding does not supports anytree's unicode markers
+    # ref https://github.com/pallets/click/issues/2121#issuecomment-1809693939
+    # so check for UTF-8 mode https://docs.python.org/3/library/os.html#utf8-mode
+    # PEP 686: Python 3.15 will make Python UTF-8 Mode default
+    if not sys.stdout.encoding.lower().startswith("utf"):  # pragma: no cover
         tree_ascii = True
     style = AsciiStyle() if tree_ascii else ContStyle()
     output = []

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -168,7 +168,11 @@ def render_tree(tree_root, max_depth, tree_ascii=False):
     # ref https://github.com/pallets/click/issues/2121#issuecomment-1809693939
     # so check for UTF-8 mode https://docs.python.org/3/library/os.html#utf8-mode
     # PEP 686: Python 3.15 will make Python UTF-8 Mode default
-    if not sys.stdout.encoding.lower().startswith("utf"):  # pragma: no cover
+    if (  # pragma: no cover
+        not tree_ascii
+        and hasattr(sys.stdout, "encoding")
+        and not sys.stdout.encoding.lower().startswith("utf")
+    ):
         tree_ascii = True
     style = AsciiStyle() if tree_ascii else ContStyle()
     output = []


### PR DESCRIPTION
ref https://github.com/ddelange/pipgrip/pull/128#issuecomment-1809586931

cc @kurtmckee