### PR TITLE
:bug: Fix package reports on Google Colab

### DIFF
--- a/src/pipgrip/pipper.py
+++ b/src/pipgrip/pipper.py
@@ -309,19 +309,20 @@ def _get_package_report(
             "--trusted-host",
             urlparse(extra_index_url).hostname,
         ]
-    args += ["--report", "-", package]
-    try:
-        out = stream_bash_command(args)
-    except subprocess.CalledProcessError as err:
-        output = getattr(err, "output") or ""
-        logger.error(
-            "Getting report for {} failed with output:\n{}".format(
-                package, output.strip()
+
+    with NamedTemporaryFile() as fp:
+        args += ["--report", fp.name, package]
+        try:
+            stream_bash_command(args)
+        except subprocess.CalledProcessError as err:
+            output = getattr(err, "output") or ""
+            logger.error(
+                "Getting report for {} failed with output:\n{}".format(
+                    package, output.strip()
+                )
             )
-        )
-        raise RuntimeError("Failed to get report for {}".format(package))
-    report = json.loads(out)
-    return report
+            raise RuntimeError("Failed to get report for {}".format(package))
+        return json.load(fp)
 
 
 def _download_wheel(

--- a/tests/test_pipper.py
+++ b/tests/test_pipper.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 
@@ -258,7 +259,9 @@ def test_download_wheel(package, pip_output, expected, monkeypatch):
 )
 def test_get_package_report(package, pip_output, expected, monkeypatch):
     def patch_pip_output(*args, **kwargs):
-        return pip_output
+        file_path = args[0][-2]
+        with open(file_path, "w") as fp:
+            json.dump(json.loads(pip_output), fp)
 
     def patch_getcwd():
         return os.path.expanduser("~")


### PR DESCRIPTION
Somehow Google Colab is forcing colored report output, and even adding `--no-color` isn't disabling it. Switching to temp file to make pipgrip robust to this config.

The ANSI escapes result in:
```pytb
Traceback (most recent call last):
  File "/usr/local/bin/pipgrip", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/pipgrip/cli.py", line 446, in main
    solution = solver.solve()
  File "/usr/local/lib/python3.10/dist-packages/pipgrip/libs/mixology/version_solver.py", line 74, in solve
    if not self._run():
  File "/usr/local/lib/python3.10/dist-packages/pipgrip/libs/mixology/version_solver.py", line 90, in _run
    next_package = self._choose_package_version()
  File "/usr/local/lib/python3.10/dist-packages/pipgrip/libs/mixology/version_solver.py", line 363, in _choose_package_version
    versions = self._source.versions_for(term.package, term.constraint.constraint)
  File "/usr/local/lib/python3.10/dist-packages/pipgrip/libs/mixology/package_source.py", line 77, in versions_for
    return self._versions_for(package, constraint)
  File "/usr/local/lib/python3.10/dist-packages/pipgrip/package_source.py", line 192, in _versions_for
    self.discover_and_add(package.req.__str__())
  File "/usr/local/lib/python3.10/dist-packages/pipgrip/package_source.py", line 148, in discover_and_add
    to_create = discover_dependencies_and_versions(
  File "/usr/local/lib/python3.10/dist-packages/pipgrip/pipper.py", line 516, in discover_dependencies_and_versions
    report = _get_package_report(
  File "/usr/local/lib/python3.10/dist-packages/pipgrip/pipper.py", line 323, in _get_package_report
    report = json.loads(out)
  File "/usr/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 6 (char 5)
```