### PR TITLE
:bug: Exclude 5.0rc1 when <5 is requested

### DIFF
--- a/tests/tests_mixology/test_basic_graph.py
+++ b/tests/tests_mixology/test_basic_graph.py
@@ -95,3 +95,30 @@ def test_circular_dependency(source):
     source.add("bar", "1.0.0", deps={"foo": "1.0.0"})
 
     check_solver_result(source, {"foo": "1.0.0", "bar": "1.0.0"})
+
+
+def test_prerelease_lte(source):
+    source.root_dep("foo", "<=5")
+
+    source.add("foo", "4.1.1")
+    source.add("foo", "5.0rc1")
+
+    check_solver_result(source, {"foo": "5.0rc1"})
+
+
+def test_prerelease_lt(source):
+    source.root_dep("foo", "<5")
+
+    source.add("foo", "4.1.1")
+    source.add("foo", "5.0rc1")
+
+    check_solver_result(source, {"foo": "4.1.1"})
+
+
+def test_prerelease_gte(source):
+    source.root_dep("foo", ">=5.0.0a0")
+
+    source.add("foo", "4.1.1")
+    source.add("foo", "5.0rc1")
+
+    check_solver_result(source, {"foo": "5.0rc1"})

--- a/tests/tests_mixology/test_unsolvable.py
+++ b/tests/tests_mixology/test_unsolvable.py
@@ -48,6 +48,21 @@ def test_no_version_matching_constraint(source):
     )
 
 
+def test_prerelease(source):
+    source.root_dep("foo", "<5")
+
+    source.add("foo", "5.0rc1")
+    source.add("foo", "5.0")
+
+    check_solver_result(
+        source,
+        error=(
+            "Because root depends on foo (<5) "
+            "which doesn't match any versions, version solving failed."
+        ),
+    )
+
+
 def test_no_version_that_matches_combined_constraints(source):
     source.root_dep("foo", "1.0.0")
     source.root_dep("bar", "1.0.0")


### PR DESCRIPTION
Before this change, `pipgrip --pre 'django<5.0'` would select django==5.0rc1 (because that is technically a version that comes before 5.0), whereas `pip install --pre 'django<5.0'` will select django==4.2.11. This PR fixes behaviour parity with pip.