### PR TITLE
:children_crossing: Show partial solution on build errors

### DIFF
--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -52,7 +52,12 @@ from pipgrip.libs.mixology.failure import SolverFailure
 from pipgrip.libs.mixology.package import Package
 from pipgrip.libs.mixology.version_solver import VersionSolver
 from pipgrip.package_source import PackageSource, render_pin
-from pipgrip.pipper import install_packages, read_requirements
+from pipgrip.pipper import (
+    BUILD_FAILURE_STR,
+    REPORT_FAILURE_STR,
+    install_packages,
+    read_requirements,
+)
 
 logging.basicConfig(format="%(levelname)s: %(message)s")
 logger = logging.getLogger()
@@ -479,10 +484,7 @@ def main(
             exc = None
         except RuntimeError as e:
             # RuntimeError coming from pipgrip.pipper
-            if (
-                "Failed to download/build wheel for" not in str(e)
-                and "Failed to get report for" not in str(e)
-            ):
+            if REPORT_FAILURE_STR not in str(e) and BUILD_FAILURE_STR not in str(e):
                 # only continue handling expected RuntimeErrors
                 raise
             solution = solver.solution

--- a/src/pipgrip/cli.py
+++ b/src/pipgrip/cli.py
@@ -479,7 +479,10 @@ def main(
             exc = None
         except RuntimeError as e:
             # RuntimeError coming from pipgrip.pipper
-            if "Failed to download/build wheel" not in str(e):
+            if (
+                "Failed to download/build wheel for" not in str(e)
+                and "Failed to get report for" not in str(e)
+            ):
                 # only continue handling expected RuntimeErrors
                 raise
             solution = solver.solution

--- a/src/pipgrip/pipper.py
+++ b/src/pipgrip/pipper.py
@@ -49,6 +49,10 @@ from pipgrip.compat import PIP_VERSION, urlparse
 
 logger = logging.getLogger(__name__)
 
+REPORT_FAILURE_STR = "Failed to get report for"
+BUILD_FAILURE_STR = "Failed to download/build wheel for"
+VERSIONS_FAILURE_STR = "Failed to get available versions for"
+
 
 def read_requirements(path):
     re_comments = re.compile(r"(?:^|\s+)#")
@@ -292,7 +296,7 @@ def _get_available_versions(package, index_url, extra_index_url, pre):
             ]
             _available_versions_cache[cache_key] = available_versions
             return available_versions
-    raise RuntimeError("Failed to get available versions for {}".format(package))
+    raise RuntimeError("{} {}".format(VERSIONS_FAILURE_STR, package))
 
 
 def _get_package_report(
@@ -357,7 +361,7 @@ def _get_package_report(
                 package, output.strip()
             )
         )
-        raise RuntimeError("Failed to get report for {}".format(package))
+        raise RuntimeError("{} {}".format(REPORT_FAILURE_STR, package))
     else:
         with io.open(report_file, "r", encoding="utf-8") as fp:
             return json.load(fp)
@@ -397,7 +401,7 @@ def _download_wheel(
                 package, output.strip()
             )
         )
-        raise RuntimeError("Failed to download/build wheel for {}".format(package))
+        raise RuntimeError("{} {}".format(BUILD_FAILURE_STR, package))
     out = out.splitlines()[::-1]
     abs_wheel_dir_lower = abs_wheel_dir.lower()
     cwd_wheel_dir_lower = cwd_wheel_dir.lower()
@@ -474,7 +478,7 @@ def _download_wheel(
             "\n".join(out[::-1])
         )
     )
-    raise RuntimeError("Failed to download/build wheel for {}".format(package))
+    raise RuntimeError("{} {}".format(BUILD_FAILURE_STR, package))
 
 
 def _extract_metadata(wheel_fname):


### PR DESCRIPTION
#113 indroduced `--dry-run --report` which broke the logic here to show a partial best guess tree on failures.